### PR TITLE
Use more then one side for half violins

### DIFF
--- a/R/geom_half_violin.R
+++ b/R/geom_half_violin.R
@@ -9,11 +9,11 @@
 #' @param side The side on which to draw the half violin plot. "l" for left, "r" for right, defaults to "l".
 #' @param nudge Add space between the violinplot and the middle of the space allotted to a given factor on the x-axis.
 #' @importFrom ggplot2 layer
-#' @examples 
-#' ggplot(iris, aes(x = Species, y = Petal.Width, fill = Species)) + 
+#' @examples
+#' ggplot(iris, aes(x = Species, y = Petal.Width, fill = Species)) +
 #'   geom_half_violin()
-#'   
-#' ggplot(iris, aes(x = Species, y = Petal.Width, fill = Species)) + 
+#'
+#' ggplot(iris, aes(x = Species, y = Petal.Width, fill = Species)) +
 #'   geom_half_violin(side = "r")
 #' @export
 #' @references Hintze, J. L., Nelson, R. D. (1998) Violin Plots: A Box
@@ -65,9 +65,15 @@ GeomHalfViolin <- ggproto(
     data
   },
 
+  setup_params = function(data, params) {
+    params$side <- rep(params$side, 
+                      ceiling(length(unique(data$group))/length(params$side)))
+    params
+  },
+  
   draw_group = function(self, data, side = "l", nudge = 0, ..., draw_quantiles = NULL) {
     # Find the points for the line to go all the way around
-    if (side == "l") {
+    if (side[unique(data$group)] == "l") {
       data <- transform(
         data,
         xminv = x + violinwidth * (xmin - x) - nudge,
@@ -80,7 +86,7 @@ GeomHalfViolin <- ggproto(
         xmaxv = x + violinwidth * (xmax - x) + nudge
       )
     }
-    
+
     # Make sure it's sorted properly to draw the outline
     newdata <- rbind(
       transform(data, x = xminv)[order(data$y), ],
@@ -90,11 +96,11 @@ GeomHalfViolin <- ggproto(
     # Close the polygon: set first and last point the same
     # Needed for coord_polar and such
     newdata <- rbind(newdata, newdata[1,])
-    
+
     # Draw quantiles if requested, so long as there is non-zero y range
     if (length(draw_quantiles) > 0 & !scales::zero_range(range(data$y))) {
       stopifnot(all(draw_quantiles >= 0), all(draw_quantiles <= 1))
-      
+
       # Compute the quantile segments and combine with existing aesthetics
       quantiles <- ggplot2:::create_quantile_segment_frame(data, draw_quantiles)
       aesthetics <- data[
@@ -110,7 +116,7 @@ GeomHalfViolin <- ggproto(
       } else {
         GeomPath$draw_panel(both, ...)
       }
-      
+
       ggplot2:::ggname("geom_half_violin", grobTree(
         GeomPolygon$draw_panel(newdata, ...),
         quantile_grob)


### PR DESCRIPTION
Adds the possibility to use more than one side (e.g. c("r", "l")) for geom_half_violin.
Inspired by the solution in geom_violinhalf in [see](https://github.com/easystats/see).

`ggplot(ToothGrowth, aes(x = supp, y = len, color = supp)) +
   geom_half_violin(side = c("l","r")) `