### PR TITLE
fix geom_half_point transformation defaults

### DIFF
--- a/R/geom_half_point.R
+++ b/R/geom_half_point.R
@@ -18,7 +18,7 @@ geom_half_point <- function(
   stat = "HalfPoint", position = "dodge2",
   ...,
   side = "r",
-  transformation = position_jitter(),
+  transformation = position_jitter(height = 0),
   # transformation_params = list(width = NULL, height = NULL),
   range_scale = .75,
   na.rm = FALSE,

--- a/R/geom_half_point_panel.R
+++ b/R/geom_half_point_panel.R
@@ -14,7 +14,7 @@ geom_half_point_panel <- function(
   stat = "identity", position = "identity",
   ...,
   side = "r",
-  transformation = position_jitter(),
+  transformation = position_jitter(height = 0),
   range_scale = .75,
   na.rm = FALSE,
   show.legend = NA,


### PR DESCRIPTION
Fixes https://github.com/erocoar/gghalves/issues/26.
Avoids jittering points in y by default, which may be a more sensible setting for most use cases.