### PR TITLE
Compatibility with ggplot2 4.0.0

### DIFF
--- a/R/geom_half_point.R
+++ b/R/geom_half_point.R
@@ -137,7 +137,13 @@ GeomHalfPoint <- ggproto(
     #     ggplot2::resolution(data$point_y[[1]], zero = FALSE) * 0.4
     # }
 
-    if (is(transformation, "PositionIdentity") || is(transformation, "PositionJitter")) {
+    # Practical test if ggplot2 is at version 4.x.x+
+    ggplot2_version_400 <- "class_ggplot" %in% getNamespaceExports("ggplot2")
+
+    if (
+      is(transformation, "PositionIdentity") ||
+      (is(transformation, "PositionJitter") && !ggplot2_version_400)
+    ) {
       trans_positions <- transformation$compute_layer(
         transformation_df,
         transformation_params_new

--- a/R/geom_half_point_panel.R
+++ b/R/geom_half_point_panel.R
@@ -98,7 +98,13 @@ GeomHalfPointPanel <- ggproto(
         ggplot2::resolution(data$y, zero = FALSE) * 0.4
     }
 
-    if (is(transformation, "PositionIdentity") || is(transformation, "PositionJitter")) {
+    # Practical test if ggplot2 is at version 4.x.x+
+    ggplot2_version_400 <- "class_ggplot" %in% getNamespaceExports("ggplot2")
+
+    if (
+      is(transformation, "PositionIdentity") ||
+      (is(transformation, "PositionJitter") && !ggplot2_version_400)
+    ) {
       trans_positions <- transformation$compute_layer(
         transformation_df,
         transformation_params


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue was a missing `layout` argument to `Position$compute_layer()`, and this PR works around that problem for `PositionJitter`.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit an update to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
